### PR TITLE
Export Metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.dll
 *.so
 *.dylib
+Gomodoro
 
 # Test binary, build with `go test -c`
 *.test

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"log"
 
 	t "github.com/OompahLoompah/Gomodoro/pkg/timer"
 	"github.com/0xAX/notificator"
@@ -47,7 +48,10 @@ This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
         Run: func(cmd *cobra.Command, args []string) {
 		if seconds > 0 {
-			t.Timer(seconds, notifier)
+			err := t.Timer(seconds, notifier)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,8 +23,8 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"time"
 
+	t "github.com/OompahLoompah/Gomodoro/pkg/timer"
 	"github.com/0xAX/notificator"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -46,9 +46,8 @@ Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
         Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("set called")
 		if seconds > 0 {
-			setTimer(seconds)
+			t.Timer(seconds, notifier)
 		}
 	},
 }
@@ -101,10 +100,9 @@ func initConfig() {
 	}
 }
 
-func setTimer(t int) {
+func notifier() {
 	notify = notificator.New(notificator.Options{
 		AppName:          "Pomodoro Timer",
 	})
-	time.Sleep(time.Duration(t) * time.Second)
 	notify.Push("", "Time's up!", "", notificator.UR_CRITICAL)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,39 @@
+package metrics
+
+import (
+	"os"
+	"net"
+)
+
+func Push(message []byte, srv string) error{
+	if srv == "" {
+		addr := os.Getenv("GOMO_METRICS_SRV")
+		if addr == "" {
+			//TODO: log error sensibly instead of ignoring or mixing non-fatal and fatal errs in return. 
+			return nil
+		}
+		port := os.Getenv("GOMO_METRICS_PORT")
+		if port == "" {
+			//TODO: log error sensibly instead of ignoring or mixing non-fatal and fatal errs in return. 
+			return nil
+		}
+		srv = addr + ":" + port
+	}
+	conn, err := net.Dial("tcp",srv)
+	if err != nil {
+		return err
+	}
+	_, err = conn.Write(message)
+	if err != nil {
+		err = conn.Close()
+		if err != nil{
+			return err
+		}
+		return err
+	}
+	err = conn.Close()
+	if err != nil {
+		return err
+	}
+        return nil
+}

--- a/pkg/timer/timer.go
+++ b/pkg/timer/timer.go
@@ -1,0 +1,14 @@
+package timer
+
+import (
+	"time"
+)
+
+type fn func() 
+
+func Timer(t int, notifier fn) {
+	time.Sleep(time.Duration(t) * time.Second)
+	if notifier != nil {
+		notifier()
+	}
+}

--- a/pkg/timer/timer.go
+++ b/pkg/timer/timer.go
@@ -2,13 +2,30 @@ package timer
 
 import (
 	"time"
+	json "encoding/json"
+
+	metrics "github.com/OompahLoompah/Gomodoro/pkg/metrics"
 )
 
-type fn func() 
+type timerMetric struct {
+	seconds   int
+	cancelled bool
+}
 
-func Timer(t int, notifier fn) {
+func Timer(t int, notifier func()) error {
 	time.Sleep(time.Duration(t) * time.Second)
 	if notifier != nil {
 		notifier()
 	}
+
+	w := timerMetric{t, false}
+	m, err := json.Marshal(w)
+	if err != nil {
+		return err
+	}
+	err = metrics.Push(m, "")
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
Creates a metrics pusher for Telegraf's socket listener exporting the number of seconds set for each pomodoro.